### PR TITLE
Initialize backend skeleton for Telegram Mini App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Telegram Mini App for Insurance Agents
+
+This repository contains a skeleton implementation following the proposed plan for a Telegram Mini App that serves as a personal cabinet for insurance agents. It includes:
+
+- **Backend**: Node.js/Express API placeholder.
+- **Future modules**: Integration with Bitrix24, training materials, gamification.
+
+To start the backend server:
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+Tests can be executed via:
+
+```bash
+npm test
+```
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "telegram-mini-app-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "NODE_ENV=test node test/run-tests.js"
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,32 @@
+import http from 'node:http';
+
+function handleRequest(req, res) {
+  const { method, url } = req;
+  if (method === 'POST' && url === '/api/requests') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      const payload = body ? JSON.parse(body) : null;
+      res.end(JSON.stringify({ message: 'Request received', data: payload }));
+    });
+  } else if (method === 'GET' && url.startsWith('/api/requests/') && url.endsWith('/status')) {
+    const id = url.split('/')[3];
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id, status: 'pending' }));
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+}
+
+export function createServer() {
+  return http.createServer(handleRequest);
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  createServer().listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}

--- a/backend/test/run-tests.js
+++ b/backend/test/run-tests.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import http from 'node:http';
+import { createServer } from '../src/index.js';
+
+const server = createServer().listen(0, () => {
+  const { port } = server.address();
+  const options = {
+    hostname: '127.0.0.1',
+    port,
+    path: '/api/requests/123/status',
+    method: 'GET'
+  };
+
+  const req = http.request(options, res => {
+    let data = '';
+    res.on('data', chunk => (data += chunk));
+    res.on('end', () => {
+      const obj = JSON.parse(data);
+      assert.strictEqual(obj.id, '123');
+      assert.strictEqual(obj.status, 'pending');
+      console.log('basic test passed');
+      server.close();
+    });
+  });
+
+  req.on('error', err => {
+    console.error(err);
+    server.close();
+  });
+
+  req.end();
+});


### PR DESCRIPTION
## Summary
- add repository README and gitignore
- implement minimal Node.js backend using built-in http server
- add basic test verifying request status endpoint

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a06430dc832fb93afb0044a98c16